### PR TITLE
:gift: add nginx-proxy to support host name

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,13 @@
 version: '2'
 
 services:
+        nginx-proxy:
+                image: jwilder/nginx-proxy
+                container_name: nginx-proxy
+                ports:
+                        - "80:80"
+                volumes:
+                        - /var/run/docker.sock:/tmp/docker.sock:ro
         mysql:
                 image: mysql
                 environment:
@@ -11,3 +18,5 @@ services:
                         - mysql
                 ports:
                         - 8080:80
+                environment:
+                        - VIRTUAL_HOST=<YOUR HOST>


### PR DESCRIPTION
Hello @MoriTanosuke,

I added nginx-proxy to your docker-compose.yml and successfully register my license for fever using the hostname I used for my fever account.

Once the host is configured in the docker-compose.yml (replace `<YOUR HOST>`), you can go to `http://<YOUR HOST>/fever/boot.php`.

I had one issue, some errors like:

> Warning: mktime(): It is not safe to rely on the system's timezone settings. You are _required_ to use the date.timezone setting or the date_default_timezone_set() function. In case you used any of those methods and you are still getting this warning, you most likely misspelled the timezone identifier. We selected the timezone 'UTC' for now, but please set date.timezone to select your timezone. in /var/www/html/fever/firewall/tmp/pclzip.lib.php on line 4296

Refreshing the page brought the installation page correctly.

Hope this helps !
